### PR TITLE
Update MHS35-show - add dependencies

### DIFF
--- a/MHS35-show
+++ b/MHS35-show
@@ -45,6 +45,7 @@ echo "gpio:resistance:mhs35:90:480:320" > ./.have_installed
 wget --spider -q -o /dev/null --tries=1 -T 10 https://cmake.org/
 if [ $? -eq 0 ]; then
 sudo apt-get update
+sudp apt-get install apt-utils build-essential -y 2> error_output.txt
 sudo apt-get install cmake -y 2> error_output.txt
 result=`cat ./error_output.txt`
 echo -e "\033[31m$result\033[0m"


### PR DESCRIPTION
On systems where apt-utils or build-essentials are not installed the script runs into errors. 